### PR TITLE
Phase 3: Remove MCP server in favor of direct tool calls

### DIFF
--- a/docs/Phase3.md
+++ b/docs/Phase3.md
@@ -7,7 +7,7 @@
 - `Phase3.md` - Implementation details, timelines, checklists, Phase 3-specific flows
 
 **Cross-References:**
-- MCP Server Tools → See `TECHNICAL_DESIGN.md` section "MCP Server" for complete tool definitions
+- Tool Calls → See `TECHNICAL_DESIGN.md` section "Tool Calls (Direct Integration)" for complete tool definitions
 - WebSocket Protocol → Phase 2a prerequisite (implemented in Phase 2a)
 - LLM Tool Calling → Phase 3-specific tool definitions in section "LLM Tool Definitions" below
 - Component Transformer → Phase 3 implementation in section "Component Transformer Pipeline" below
@@ -143,7 +143,7 @@ data: {"type":"ready","port":3002,"timestamp":1234567892}
 - ✅ Centralized control (backend manages all services)
 - ✅ Real-time visibility (logs streamed to UI)
 - ✅ Resource efficiency (stop when not needed)
-- ✅ MCP-ready (future: expose as MCP tools)
+- ✅ Tool-ready (future: expose as additional tool calls)
 - ✅ Error recovery (auto-restart, status monitoring)
 
 ### 3. iframe Sandboxing
@@ -1124,26 +1124,6 @@ CREATE TABLE components (
 
 ---
 
-### 6.3. MCP Server Integration
-
-**Purpose:** Expose design system to LLM for introspection during code generation
-
-**Location:** `apps/server/src/mcp/`
-
-**MCP Tools Available to LLM:**
-- `list_components` - Return all available components with summaries
-- `get_component(name)` - Return full component definition (props, variants)
-- `get_tokens(type)` - Return design tokens by category
-- `check_composition_rules(parent, child)` - Validate component nesting
-- `search_components(query)` - Find components by semantic purpose
-
-**Phase 3 Usage:**
-In Phase 3 (free-form generation), MCP tools are **not yet enforced**. LLM can use any React components. MCP integration becomes critical in Phase 4 (Design System Mode).
-
-**See `docs/TECHNICAL_DESIGN.md` section "MCP Server"** for complete tool definitions.
-
----
-
 ### 7. Preview Communication Bridge
 
 **Decision:** postMessage API for cross-origin communication (3000 ↔ 3002)
@@ -2119,8 +2099,7 @@ Phase 3 relies on Phase 2a's WebSocket infrastructure for messaging:
 
 Phase 4 will add:
 - Design System Mode (tokens, components, rules as code)
-- MCP server for LLM introspection of design system
-- **MCP tools for preview server control** (start/stop/status/logs)
+- Direct tool calls for LLM introspection (`list_components`, `get_component`, etc.)
 - Validation engine (semantic props, design system rules)
 - Select/Preview modes with property editors
 - Database index for component usage tracking


### PR DESCRIPTION
## Summary

Removes MCP server protocol from Phase 3 implementation in favor of direct tool calls via Vercel AI SDK.

## Changes

### Architecture Decision
- **Direct tool calls** instead of MCP protocol
- All tools exposed via Vercel AI SDK (`tool()` function)
- Same functionality with simpler architecture

### Documentation Updates

**Phase3.md:**
- Removed section 6.3 (MCP Server Integration)
- Updated cross-references to point to "Tool Calls (Direct Integration)"
- Changed "MCP-ready" to "Tool-ready" in preview server rationale
- Updated Phase 4 notes to reference direct tool calls

**PRD.md:**
- Clarified Phase 3 uses direct tool calls (no MCP)
- Updated Phase 4 to specify direct tool calls for design system introspection
- Updated LLM Integration section to reflect new approach

**TECHNICAL_DESIGN.md:**
- Renamed section from "MCP Server" to "Tool Calls (Direct Integration)"
- Updated implementation paths from `src/mcp/` to `src/tools/`
- Removed `@modelcontextprotocol/sdk` from dependencies
- Updated LLM instructions to reference tool calls

## Benefits

- ✅ Simpler architecture (no MCP protocol overhead)
- ✅ Direct integration with existing Vercel AI SDK
- ✅ Easier debugging and testing
- ✅ Same functionality without protocol complexity
- ✅ One less dependency to manage

## Out of Scope

- Design system tool calls (Phase 4)
- File system tools implementation (Phase 3, already documented)

## Testing

- Documentation review only (no code changes)
- Implementation checklist in Phase3.md ready for development