### PR TITLE
feat: Add git commit permissions to orchestrator agent

### DIFF
--- a/.opencode/agents/orchestrate.md
+++ b/.opencode/agents/orchestrate.md
@@ -16,6 +16,14 @@ permission:
     "AGENTS.md": allow
     "*.md": allow
     "*": deny
+  bash:
+    "git add *": allow
+    "git commit *": allow
+    "git status": allow
+    "git diff *": allow
+    "git log *": allow
+    "git push *": allow
+    "*": deny
 ---
 
 You are an **Orchestration Agent** responsible for coordinating the implementation of large features across multiple specialized agents.
@@ -107,10 +115,24 @@ For each task in your plan:
     If everything passes:
    1. Report what was verified (including validation results)"
 
-3. **Handle Review Feedback:**
-   - If reviewer found issues -> Spawn implementer to fix, then wait for re-review
-   - If reviewer approved -> **YOU mark the task complete** in the progress file, then move to next task
-   - If reviewer needs clarification -> Provide context
+ 3. **Handle Review Feedback:**
+    - If reviewer found issues -> Spawn implementer to fix, then wait for re-review
+    - If reviewer approved -> **YOU mark the task complete** in the progress file, then move to next task
+    - If reviewer needs clarification -> Provide context
+
+4. **Commit Completed Milestones:**
+    - After a **major milestone** (logical unit of work) is complete, commit the changes
+    - A milestone is a group of related tasks that form a complete feature (e.g., "backend API complete", "UI components complete")
+    - Do NOT commit after every single task - batch related tasks into meaningful commits
+    - Use descriptive commit messages:
+      ```bash
+      git add .
+      git status
+      git commit -m "feat: [brief description of completed milestone]
+      
+      - [summary of changes]
+      - [tasks completed]"
+      ```
 
 **Note:** YOU are responsible for marking ALL tasks complete (both implementation tasks and reviewer tasks) based on the reports you receive. Update the progress files accordingly.
 
@@ -238,13 +260,14 @@ You:
 4. **ALWAYS run validation** - Before marking feature complete
 5. **Document decisions** - Keep a record of key choices made
 6. **Escalate blockers** - If stuck, report to user immediately
+7. **COMMIT after major milestones** - Batch related tasks into meaningful commits (not after every task)
 
 ## Tools Available
 
 - `read` - Read files and documentation
 - `glob` - Find files by pattern
 - `grep` - Search for code patterns
-- `bash` - Run commands (validations, tests, etc.)
+- `bash` - Run commands (validations, tests, git operations)
 - `task` - Spawn subagents for implementation/review
 
 ## When to Ask the User


### PR DESCRIPTION
## Summary
- Add git bash permissions to orchestrator agent (add, commit, status, diff, log, push)
- Add milestone commit workflow: automatically commit after major milestones complete
- Define milestones as logical units of work (groups of related tasks)
- Update agent rules to include commit after major milestones

## Changes
- `.opencode/agents/orchestrate.md` - Added git permissions and commit workflow instructions

## Testing
- Agent configuration updated to enable git operations
- Commits will be batched by milestone, not individual tasks