### PR TITLE
fix: Add graceful shutdown handlers to server

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -57,6 +57,25 @@ const server = app.listen(PORT, () => {
 
 new WebSocketHandler(server);
 
+// Graceful shutdown handlers
+function gracefulShutdown(signal: string) {
+  console.log(`\nReceived ${signal}. Shutting down gracefully...`);
+  
+  server.close(() => {
+    console.log('HTTP server closed');
+    process.exit(0);
+  });
+  
+  // Force close after 10 seconds
+  setTimeout(() => {
+    console.error('Forcing shutdown after timeout');
+    process.exit(1);
+  }, 10000);
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+
 app.use(cors({
   origin: FRONTEND_URL,
   credentials: true,


### PR DESCRIPTION
## Summary

Fixes port hanging issue on Windows when stopping PM2 processes.

## Problem

When running `pm2 stop` or `pm2 restart` on Windows, Node.js processes would not properly close HTTP servers, leaving ports in LISTENING state. This required manual process termination with `taskkill`.

## Solution

Added graceful shutdown signal handlers to `apps/server/src/index.ts`:

- Handles SIGTERM and SIGINT signals from PM2
- Properly closes HTTP server before exit
- Force exits after 10 second timeout if graceful shutdown fails

## Testing

✅ Tested with `pm2 kill` → clear ports → `pm2 start` → `pm2 stop`
✅ All ports (3000, 3001, 3002) released immediately after stop
✅ No hanging processes observed
✅ Server restarts cleanly

## Related

This is a known issue with Node.js on Windows when processes don't handle shutdown signals properly. The fix ensures proper cleanup of network resources.