### PR TITLE
feat: add delete all sessions button and e2e tests

### DIFF
--- a/apps/server/src/sessions/storage.ts
+++ b/apps/server/src/sessions/storage.ts
@@ -121,6 +121,18 @@ export async function deleteSession(id: string): Promise<boolean> {
   }
 }
 
+export async function deleteAllSessions(): Promise<void> {
+  await ensureSessionsDir();
+  const entries = await fs.readdir(SESSIONS_DIR, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      const sessionDir = join(SESSIONS_DIR, entry.name);
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  }
+}
+
 export async function addMessage(sessionId: string, message: StoredMessage): Promise<void> {
   const sessionDir = join(SESSIONS_DIR, sessionId);
   const messagesPath = join(sessionDir, 'messages.jsonl');

--- a/apps/server/src/trpc/routers/sessions.ts
+++ b/apps/server/src/trpc/routers/sessions.ts
@@ -5,6 +5,7 @@ import {
   createSession,
   getSession,
   deleteSession,
+  deleteAllSessions,
 } from '../../sessions/storage.js';
 
 export const sessionsRouter = router({
@@ -41,4 +42,10 @@ export const sessionsRouter = router({
       }
       return { success: true };
     }),
+
+  // DELETE /api/sessions/all - Delete all sessions
+  deleteAll: publicProcedure.mutation(async () => {
+    await deleteAllSessions();
+    return { success: true };
+  }),
 });

--- a/apps/web/src/components/chat/SessionSelector.tsx
+++ b/apps/web/src/components/chat/SessionSelector.tsx
@@ -13,18 +13,21 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ClearAllIcon from '@mui/icons-material/ClearAll';
 import type { Session } from '../../api/client';
-import { useSessions, useCreateSession, useDeleteSession, useGetSession } from '../../hooks/useSession';
+import { useSessions, useCreateSession, useDeleteSession, useGetSession, useDeleteAllSessions } from '../../hooks/useSession';
 import { useCurrentSessionId } from '../../hooks/useSession';
 
 function SessionSelector() {
   const { sessions, sessionLabelsMap } = useSessions();
   const { createSession } = useCreateSession();
   const { deleteSession } = useDeleteSession();
+  const { deleteAllSessions } = useDeleteAllSessions();
   const { getSessionById } = useGetSession();
   const { currentSessionId, setCurrentSessionId } = useCurrentSessionId();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [sessionToDelete, setSessionToDelete] = useState<string | null>(null);
+  const [deleteAllDialogOpen, setDeleteAllDialogOpen] = useState(false);
 
   const handleCreateSession = async () => {
     try {
@@ -46,6 +49,16 @@ function SessionSelector() {
       setSessionToDelete(null);
     } catch (error) {
       console.error('Failed to delete session:', error);
+    }
+  };
+
+  const handleDeleteAllSessions = async () => {
+    try {
+      await deleteAllSessions();
+      setCurrentSessionId(null);
+      setDeleteAllDialogOpen(false);
+    } catch (error) {
+      console.error('Failed to delete all sessions:', error);
     }
   };
 
@@ -91,6 +104,11 @@ function SessionSelector() {
           </IconButton>
         </Tooltip>
       )}
+      <Tooltip title="Delete All Sessions">
+        <IconButton data-testid="delete-all-sessions-button" onClick={() => setDeleteAllDialogOpen(true)} color="error">
+          <ClearAllIcon />
+        </IconButton>
+      </Tooltip>
 
       {/* Delete Dialog */}
       <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)} data-testid="delete-dialog">
@@ -102,6 +120,20 @@ function SessionSelector() {
           <Button onClick={() => setDeleteDialogOpen(false)} data-testid="cancel-delete-button">Cancel</Button>
           <Button onClick={handleDeleteSession} variant="contained" color="error" data-testid="confirm-delete-button">
             Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete All Dialog */}
+      <Dialog open={deleteAllDialogOpen} onClose={() => setDeleteAllDialogOpen(false)} data-testid="delete-all-dialog">
+        <DialogTitle>Delete All Sessions</DialogTitle>
+        <DialogContent>
+          Are you sure you want to delete all sessions? This action cannot be undone.
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteAllDialogOpen(false)} data-testid="cancel-delete-all-button">Cancel</Button>
+          <Button onClick={handleDeleteAllSessions} variant="contained" color="error" data-testid="confirm-delete-all-button">
+            Delete All
           </Button>
         </DialogActions>
       </Dialog>

--- a/apps/web/src/hooks/useSession.ts
+++ b/apps/web/src/hooks/useSession.ts
@@ -136,6 +136,30 @@ export function useDeleteSession() {
 }
 
 /**
+ * Hook to delete all sessions.
+ * Automatically invalidates the sessions list on success.
+ */
+export function useDeleteAllSessions() {
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.sessions.deleteAll.useMutation({
+    onSuccess: () => {
+      utils.sessions.list.invalidate();
+    },
+  });
+
+  const deleteAllSessions = useCallback(async () => {
+    return mutation.mutateAsync();
+  }, [mutation]);
+
+  return {
+    deleteAllSessions,
+    isDeletingAll: mutation.isPending,
+    error: mutation.error,
+  };
+}
+
+/**
  * Hook to get a session by ID.
  * Uses tRPC utility to fetch without caching.
  */

--- a/tests/e2e/tests/sessions.spec.ts
+++ b/tests/e2e/tests/sessions.spec.ts
@@ -85,26 +85,78 @@ test.describe('Session Management', () => {
     await createSession();
     await authenticatedPage.waitForTimeout(500);
     await createSession();
-    
+
     // Get the session select element
     const sessionSelect = authenticatedPage.getByTestId('session-select');
-    
+
     // Get the current session value
     const currentSessionId = await sessionSelect.evaluate((el: HTMLSelectElement) => el.value);
-    
+
     // Get all session options
     const options = sessionSelect.locator('option');
     const optionCount = await options.count();
-    
+
     // If there are multiple sessions, try to select a different one
     if (optionCount > 1) {
       // Select the first option
       await sessionSelect.selectOption({ index: 0 });
       await authenticatedPage.waitForTimeout(500);
-      
+
       // Verify the selection changed
       const newSessionId = await sessionSelect.evaluate((el: HTMLSelectElement) => el.value);
       expect(newSessionId).not.toBe(currentSessionId);
     }
+  });
+
+  test('should delete all sessions', async ({ authenticatedPage, createSession }) => {
+    // Create multiple sessions
+    await createSession();
+    await createSession();
+
+    // Wait for delete all button to be visible
+    await expect(authenticatedPage.getByTestId('delete-all-sessions-button')).toBeVisible();
+
+    // Click delete all button
+    await authenticatedPage.getByTestId('delete-all-sessions-button').click();
+
+    // Confirm deletion in dialog
+    await expect(authenticatedPage.getByTestId('delete-all-dialog')).toBeVisible();
+    await authenticatedPage.getByTestId('confirm-delete-all-button').click();
+
+    // Verify delete all dialog is closed
+    await expect(authenticatedPage.getByTestId('delete-all-dialog')).not.toBeVisible();
+
+    // Verify all sessions are deleted (select should be empty or have no options)
+    const sessionSelect = authenticatedPage.getByTestId('session-select');
+    const optionsAfter = sessionSelect.locator('option');
+    const optionCountAfter = await optionsAfter.count();
+    expect(optionCountAfter).toBe(0);
+  });
+
+  test('should cancel delete all sessions', async ({ authenticatedPage, createSession }) => {
+    // Create multiple sessions
+    await createSession();
+    await createSession();
+
+    // Wait for delete all button to be visible
+    await expect(authenticatedPage.getByTestId('delete-all-sessions-button')).toBeVisible();
+
+    // Get initial session count before opening dialog
+    const sessionSelect = authenticatedPage.getByTestId('session-select');
+    const optionsBefore = sessionSelect.locator('option');
+    const optionCountBefore = await optionsBefore.count();
+
+    // Click delete all button
+    await authenticatedPage.getByTestId('delete-all-sessions-button').click();
+
+    // Cancel deletion
+    await authenticatedPage.getByTestId('cancel-delete-all-button').click();
+
+    // Verify delete all dialog is closed but sessions still exist
+    await expect(authenticatedPage.getByTestId('delete-all-dialog')).not.toBeVisible();
+
+    const optionsAfter = sessionSelect.locator('option');
+    const optionCountAfter = await optionsAfter.count();
+    expect(optionCountAfter).toBe(optionCountBefore);
   });
 });


### PR DESCRIPTION
## Summary
Adds a "Delete All Sessions" button next to the existing single-session delete button, allowing users to clear all sessions at once.

## Changes
- **Backend**: Added `deleteAllSessions()` function and `deleteAll` tRPC endpoint
- **Frontend**: Added `useDeleteAllSessions` hook and UI button with confirmation dialog
- **Tests**: Added 2 e2e tests for delete all functionality (confirm and cancel scenarios)

## Testing
- All 8 session management e2e tests pass
- TypeScript checks pass for both web and server apps

## Screenshots
The new button appears to the right of the existing trashcan button with a "ClearAll" icon.