### PR TITLE
fix: chat-log-parser not extracting message content from Qwen Code v0.13+ format

### DIFF
--- a/.qwen/skills/chat-log-parser/scripts/parse-chat-log.ts
+++ b/.qwen/skills/chat-log-parser/scripts/parse-chat-log.ts
@@ -37,6 +37,15 @@ interface ChatMessage {
   message?: {
     role: string;
     content?: string;
+    parts?: Array<{
+      text?: string;
+      thought?: boolean;
+      functionCall?: {
+        id: string;
+        name: string;
+        args: Record<string, unknown>;
+      };
+    }>;
   };
   subtype?: string;
   systemPayload?: Record<string, unknown>;
@@ -885,14 +894,37 @@ async function main(): Promise<void> {
     let content = '';
     if (msg.message?.content) {
       content = msg.message.content;
+    } else if (msg.message?.parts && msg.message.parts.length > 0) {
+      // Extract text from parts array (Qwen Code v0.13+ format)
+      const textParts = msg.message.parts
+        .filter(p => p.text && !p.thought)
+        .map(p => p.text)
+        .join('\n\n');
+      const thoughtParts = msg.message.parts
+        .filter(p => p.thought && p.text)
+        .map(p => p.text);
+      
+      if (thoughtParts.length > 0) {
+        content = `[Thinking] ${thoughtParts.join(' ')}\n\n${textParts}`.trim();
+      } else {
+        content = textParts;
+      }
     } else if (typeof msg.message === 'string') {
       content = msg.message;
     } else if (msg.systemPayload) {
       content = JSON.stringify(msg.systemPayload).substring(0, 200);
     }
 
-    // Extract tool calls
-    const toolCalls = msg.toolCalls || [];
+    // Extract tool calls from message parts (v0.13+ format)
+    let toolCalls = msg.toolCalls || [];
+    if (toolCalls.length === 0 && msg.message?.parts) {
+      toolCalls = msg.message.parts
+        .filter(p => p.functionCall)
+        .map(p => ({
+          name: p.functionCall!.name,
+          arguments: JSON.stringify(p.functionCall!.args),
+        }));
+    }
 
     return {
       timestamp: msg.timestamp,


### PR DESCRIPTION
## Summary

### Background
The chat-log-parser script was failing to extract message content from Qwen Code v0.13+ JSONL format because the message structure changed from using `message.content` to `message.parts[]` array.

### Change Overview
- Added support for `message.parts[]` array structure (Qwen Code v0.13+ JSONL format)
- Extract text content from parts, separating thinking from regular text
- Extract tool calls from `parts[].functionCall` when `toolCalls` array is empty
- Previously only checked `message.content` which is no longer populated in v0.13+

---

## Change Description

### 1. Message Content Extraction (`.qwen/skills/chat-log-parser/scripts/parse-chat-log.ts`)

**Changes:**
- Extended `ChatMessage` interface to include `message.parts[]` array with `text`, `thought`, and `functionCall` fields
- Added fallback logic to extract content from `parts[]` when `message.content` is empty
- Separates thinking content (`thought: true`) from regular text content
- Prepends `[Thinking]` marker to thought content for clear identification

**Rationale:** Qwen Code v0.13+ changed the JSONL format to use a `parts[]` array instead of populating `message.content` directly. The parser needs to handle both formats for backward compatibility.

### 2. Tool Call Extraction (`.qwen/skills/chat-log-parser/scripts/parse-chat-log.ts`)

**Changes:**
- Added fallback to extract tool calls from `parts[].functionCall` when `msg.toolCalls` array is empty
- Maps `functionCall` objects to the expected tool call format with `name` and `arguments` fields

**Rationale:** Tool calls are now embedded within the `parts[]` array structure rather than in a separate `toolCalls` array in v0.13+.

---

## Impact

| Aspect | Before | After |
|--------|--------|-------|
| **Message content extraction** | Returns empty string for v0.13+ JSONL files | Correctly extracts text from `parts[]` array |
| **Thinking content** | Lost/ignored | Captured and marked with `[Thinking]` prefix |
| **Tool call detection** | Misses tool calls in v0.13+ format | Extracts from `parts[].functionCall` as fallback |
| **Backward compatibility** | Works with old format | Works with both old and new formats |

---

## Testing

- ✅ All 63 unit tests pass
- ✅ Verified content extraction from v0.13+ JSONL format with `parts[]` structure
- ✅ Verified thinking content is properly separated and marked
- ✅ Verified tool call extraction from `functionCall` in parts
- ✅ Verified backward compatibility with legacy `message.content` format

---

## Related Files

| File | Change Type |
|------|-------------|
| `.qwen/skills/chat-log-parser/scripts/parse-chat-log.ts` | Modified |

**Net Changes:** +34 lines, -2 lines (1 file changed)
